### PR TITLE
Update .semver

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 1
 :minor: 9
-:patch: 7
+:patch: 8
 :special: ''
 :metadata: ''


### PR DESCRIPTION
bumping version to 1.9.8 to trigger nuget package update that includes AES spanning bug fix
